### PR TITLE
chore: bump version to 1.1.9 and update documentation for stepsType

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
       "Tests\\": "test/"
     }
   },
-  "version": "1.1.8",
+  "version": "1.1.9",
   "scripts": {
     "test": "phpunit"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f83302a38661c1226b6586fac00b286",
+    "content-hash": "fa07dd5ece0dbf2f76a9df8e2e886119",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",

--- a/docs/Model/TestCaseCreate.md
+++ b/docs/Model/TestCaseCreate.md
@@ -18,6 +18,7 @@ Name | Type | Description | Notes
 **milestoneId** | **int** |  | [optional]
 **automation** | **int** |  | [optional]
 **status** | **int** |  | [optional]
+**stepsType** | **string** | Determines the format of the steps field. When \&quot;classic\&quot;, steps use the standard action/expected_result/data format. When \&quot;gherkin\&quot;, steps use the {value: \&quot;Given...\\nWhen...\\nThen...\&quot;} format. | [optional] [default to 'classic']
 **attachments** | **string[]** | A list of Attachment hashes. | [optional]
 **steps** | [**\Qase\APIClientV1\Model\TestStepCreate[]**](TestStepCreate.md) |  | [optional]
 **tags** | **string[]** |  | [optional]

--- a/docs/Model/TestCaseUpdate.md
+++ b/docs/Model/TestCaseUpdate.md
@@ -18,6 +18,7 @@ Name | Type | Description | Notes
 **milestoneId** | **int** |  | [optional]
 **automation** | **int** |  | [optional]
 **status** | **int** |  | [optional]
+**stepsType** | **string** | Determines the format of the steps field. When \&quot;classic\&quot;, steps use the standard action/expected_result/data format. When \&quot;gherkin\&quot;, steps use the {value: \&quot;Given...\\nWhen...\\nThen...\&quot;} format. | [optional] [default to 'classic']
 **attachments** | **string[]** | A list of Attachment hashes. | [optional]
 **steps** | [**\Qase\APIClientV1\Model\TestStepCreate[]**](TestStepCreate.md) |  | [optional]
 **tags** | **string[]** |  | [optional]

--- a/docs/Model/TestCasebulkCasesInner.md
+++ b/docs/Model/TestCasebulkCasesInner.md
@@ -18,6 +18,7 @@ Name | Type | Description | Notes
 **milestoneId** | **int** |  | [optional]
 **automation** | **int** |  | [optional]
 **status** | **int** |  | [optional]
+**stepsType** | **string** | Determines the format of the steps field. When \&quot;classic\&quot;, steps use the standard action/expected_result/data format. When \&quot;gherkin\&quot;, steps use the {value: \&quot;Given...\\nWhen...\\nThen...\&quot;} format. | [optional] [default to 'classic']
 **attachments** | **string[]** | A list of Attachment hashes. | [optional]
 **steps** | [**\Qase\APIClientV1\Model\TestStepCreate[]**](TestStepCreate.md) |  | [optional]
 **tags** | **string[]** |  | [optional]

--- a/docs/Model/TestStepCreate.md
+++ b/docs/Model/TestStepCreate.md
@@ -4,9 +4,10 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**action** | **string** |  | [optional]
+**action** | **string** | Step action text. Used for classic steps. For gherkin steps, use the \&quot;value\&quot; property instead. | [optional]
 **expectedResult** | **string** |  | [optional]
 **data** | **string** |  | [optional]
+**value** | **string** | Gherkin scenario text. Used when steps_type is \&quot;gherkin\&quot;. Example: \&quot;Given a user exists\\nWhen they log in\\nThen they see the dashboard\&quot; | [optional]
 **position** | **int** |  | [optional]
 **attachments** | **string[]** | A list of Attachment hashes. | [optional]
 **steps** | **object[]** | Nested steps may be passed here. Use same structure for them. | [optional]

--- a/src/Model/QqlTestCase.php
+++ b/src/Model/QqlTestCase.php
@@ -391,6 +391,21 @@ class QqlTestCase implements ModelInterface, ArrayAccess, \JsonSerializable
         return self::$openAPIModelName;
     }
 
+    public const STEPS_TYPE_CLASSIC = 'classic';
+    public const STEPS_TYPE_GHERKIN = 'gherkin';
+
+    /**
+     * Gets allowable values of the enum
+     *
+     * @return string[]
+     */
+    public function getStepsTypeAllowableValues()
+    {
+        return [
+            self::STEPS_TYPE_CLASSIC,
+            self::STEPS_TYPE_GHERKIN,
+        ];
+    }
 
     /**
      * Associative array for storing property values
@@ -467,6 +482,15 @@ class QqlTestCase implements ModelInterface, ArrayAccess, \JsonSerializable
         if ($this->container['testCaseId'] === null) {
             $invalidProperties[] = "'testCaseId' can't be null";
         }
+        $allowedValues = $this->getStepsTypeAllowableValues();
+        if (!is_null($this->container['stepsType']) && !in_array($this->container['stepsType'], $allowedValues, true)) {
+            $invalidProperties[] = sprintf(
+                "invalid value '%s' for 'stepsType', must be one of '%s'",
+                $this->container['stepsType'],
+                implode("', '", $allowedValues)
+            );
+        }
+
         return $invalidProperties;
     }
 
@@ -1058,6 +1082,16 @@ class QqlTestCase implements ModelInterface, ArrayAccess, \JsonSerializable
                 unset($nullablesSetToNull[$index]);
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
+        }
+        $allowedValues = $this->getStepsTypeAllowableValues();
+        if (!is_null($stepsType) && !in_array($stepsType, $allowedValues, true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value '%s' for 'stepsType', must be one of '%s'",
+                    $stepsType,
+                    implode("', '", $allowedValues)
+                )
+            );
         }
         $this->container['stepsType'] = $stepsType;
 

--- a/src/Model/SearchResponseAllOfResultEntities.php
+++ b/src/Model/SearchResponseAllOfResultEntities.php
@@ -547,6 +547,21 @@ class SearchResponseAllOfResultEntities implements ModelInterface, ArrayAccess, 
         return self::$openAPIModelName;
     }
 
+    public const STEPS_TYPE_CLASSIC = 'classic';
+    public const STEPS_TYPE_GHERKIN = 'gherkin';
+
+    /**
+     * Gets allowable values of the enum
+     *
+     * @return string[]
+     */
+    public function getStepsTypeAllowableValues()
+    {
+        return [
+            self::STEPS_TYPE_CLASSIC,
+            self::STEPS_TYPE_GHERKIN,
+        ];
+    }
 
     /**
      * Associative array for storing property values
@@ -664,6 +679,15 @@ class SearchResponseAllOfResultEntities implements ModelInterface, ArrayAccess, 
         if ($this->container['defectId'] === null) {
             $invalidProperties[] = "'defectId' can't be null";
         }
+        $allowedValues = $this->getStepsTypeAllowableValues();
+        if (!is_null($this->container['stepsType']) && !in_array($this->container['stepsType'], $allowedValues, true)) {
+            $invalidProperties[] = sprintf(
+                "invalid value '%s' for 'stepsType', must be one of '%s'",
+                $this->container['stepsType'],
+                implode("', '", $allowedValues)
+            );
+        }
+
         return $invalidProperties;
     }
 
@@ -2035,6 +2059,16 @@ class SearchResponseAllOfResultEntities implements ModelInterface, ArrayAccess, 
                 unset($nullablesSetToNull[$index]);
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
+        }
+        $allowedValues = $this->getStepsTypeAllowableValues();
+        if (!is_null($stepsType) && !in_array($stepsType, $allowedValues, true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value '%s' for 'stepsType', must be one of '%s'",
+                    $stepsType,
+                    implode("', '", $allowedValues)
+                )
+            );
         }
         $this->container['stepsType'] = $stepsType;
 

--- a/src/Model/TestCase.php
+++ b/src/Model/TestCase.php
@@ -409,6 +409,21 @@ class TestCase implements ModelInterface, ArrayAccess, \JsonSerializable
         return self::$openAPIModelName;
     }
 
+    public const STEPS_TYPE_CLASSIC = 'classic';
+    public const STEPS_TYPE_GHERKIN = 'gherkin';
+
+    /**
+     * Gets allowable values of the enum
+     *
+     * @return string[]
+     */
+    public function getStepsTypeAllowableValues()
+    {
+        return [
+            self::STEPS_TYPE_CLASSIC,
+            self::STEPS_TYPE_GHERKIN,
+        ];
+    }
 
     /**
      * Associative array for storing property values
@@ -484,6 +499,15 @@ class TestCase implements ModelInterface, ArrayAccess, \JsonSerializable
     public function listInvalidProperties()
     {
         $invalidProperties = [];
+
+        $allowedValues = $this->getStepsTypeAllowableValues();
+        if (!is_null($this->container['stepsType']) && !in_array($this->container['stepsType'], $allowedValues, true)) {
+            $invalidProperties[] = sprintf(
+                "invalid value '%s' for 'stepsType', must be one of '%s'",
+                $this->container['stepsType'],
+                implode("', '", $allowedValues)
+            );
+        }
 
         return $invalidProperties;
     }
@@ -1049,6 +1073,16 @@ class TestCase implements ModelInterface, ArrayAccess, \JsonSerializable
                 unset($nullablesSetToNull[$index]);
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
+        }
+        $allowedValues = $this->getStepsTypeAllowableValues();
+        if (!is_null($stepsType) && !in_array($stepsType, $allowedValues, true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value '%s' for 'stepsType', must be one of '%s'",
+                    $stepsType,
+                    implode("', '", $allowedValues)
+                )
+            );
         }
         $this->container['stepsType'] = $stepsType;
 

--- a/src/Model/TestCaseCreate.php
+++ b/src/Model/TestCaseCreate.php
@@ -72,6 +72,7 @@ class TestCaseCreate implements ModelInterface, ArrayAccess, \JsonSerializable
         'milestoneId' => 'int',
         'automation' => 'int',
         'status' => 'int',
+        'stepsType' => 'string',
         'attachments' => 'string[]',
         'steps' => '\Qase\APIClientV1\Model\TestStepCreate[]',
         'tags' => 'string[]',
@@ -104,6 +105,7 @@ class TestCaseCreate implements ModelInterface, ArrayAccess, \JsonSerializable
         'milestoneId' => 'int64',
         'automation' => null,
         'status' => null,
+        'stepsType' => null,
         'attachments' => null,
         'steps' => null,
         'tags' => null,
@@ -134,6 +136,7 @@ class TestCaseCreate implements ModelInterface, ArrayAccess, \JsonSerializable
         'milestoneId' => false,
         'automation' => false,
         'status' => false,
+        'stepsType' => false,
         'attachments' => false,
         'steps' => false,
         'tags' => false,
@@ -244,6 +247,7 @@ class TestCaseCreate implements ModelInterface, ArrayAccess, \JsonSerializable
         'milestoneId' => 'milestone_id',
         'automation' => 'automation',
         'status' => 'status',
+        'stepsType' => 'steps_type',
         'attachments' => 'attachments',
         'steps' => 'steps',
         'tags' => 'tags',
@@ -274,6 +278,7 @@ class TestCaseCreate implements ModelInterface, ArrayAccess, \JsonSerializable
         'milestoneId' => 'setMilestoneId',
         'automation' => 'setAutomation',
         'status' => 'setStatus',
+        'stepsType' => 'setStepsType',
         'attachments' => 'setAttachments',
         'steps' => 'setSteps',
         'tags' => 'setTags',
@@ -304,6 +309,7 @@ class TestCaseCreate implements ModelInterface, ArrayAccess, \JsonSerializable
         'milestoneId' => 'getMilestoneId',
         'automation' => 'getAutomation',
         'status' => 'getStatus',
+        'stepsType' => 'getStepsType',
         'attachments' => 'getAttachments',
         'steps' => 'getSteps',
         'tags' => 'getTags',
@@ -355,6 +361,21 @@ class TestCaseCreate implements ModelInterface, ArrayAccess, \JsonSerializable
         return self::$openAPIModelName;
     }
 
+    public const STEPS_TYPE_CLASSIC = 'classic';
+    public const STEPS_TYPE_GHERKIN = 'gherkin';
+
+    /**
+     * Gets allowable values of the enum
+     *
+     * @return string[]
+     */
+    public function getStepsTypeAllowableValues()
+    {
+        return [
+            self::STEPS_TYPE_CLASSIC,
+            self::STEPS_TYPE_GHERKIN,
+        ];
+    }
 
     /**
      * Associative array for storing property values
@@ -385,6 +406,7 @@ class TestCaseCreate implements ModelInterface, ArrayAccess, \JsonSerializable
         $this->setIfExists('milestoneId', $data ?? [], null);
         $this->setIfExists('automation', $data ?? [], null);
         $this->setIfExists('status', $data ?? [], null);
+        $this->setIfExists('stepsType', $data ?? [], 'classic');
         $this->setIfExists('attachments', $data ?? [], null);
         $this->setIfExists('steps', $data ?? [], null);
         $this->setIfExists('tags', $data ?? [], null);
@@ -427,6 +449,15 @@ class TestCaseCreate implements ModelInterface, ArrayAccess, \JsonSerializable
         }
         if ((mb_strlen($this->container['title']) > 255)) {
             $invalidProperties[] = "invalid value for 'title', the character length must be smaller than or equal to 255.";
+        }
+
+        $allowedValues = $this->getStepsTypeAllowableValues();
+        if (!is_null($this->container['stepsType']) && !in_array($this->container['stepsType'], $allowedValues, true)) {
+            $invalidProperties[] = sprintf(
+                "invalid value '%s' for 'stepsType', must be one of '%s'",
+                $this->container['stepsType'],
+                implode("', '", $allowedValues)
+            );
         }
 
         return $invalidProperties;
@@ -822,6 +853,43 @@ class TestCaseCreate implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable status cannot be null');
         }
         $this->container['status'] = $status;
+
+        return $this;
+    }
+
+    /**
+     * Gets stepsType
+     *
+     * @return string|null
+     */
+    public function getStepsType()
+    {
+        return $this->container['stepsType'];
+    }
+
+    /**
+     * Sets stepsType
+     *
+     * @param string|null $stepsType Determines the format of the steps field. When \"classic\", steps use the standard action/expected_result/data format. When \"gherkin\", steps use the {value: \"Given...\\nWhen...\\nThen...\"} format.
+     *
+     * @return self
+     */
+    public function setStepsType($stepsType)
+    {
+        if (is_null($stepsType)) {
+            throw new \InvalidArgumentException('non-nullable stepsType cannot be null');
+        }
+        $allowedValues = $this->getStepsTypeAllowableValues();
+        if (!in_array($stepsType, $allowedValues, true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value '%s' for 'stepsType', must be one of '%s'",
+                    $stepsType,
+                    implode("', '", $allowedValues)
+                )
+            );
+        }
+        $this->container['stepsType'] = $stepsType;
 
         return $this;
     }

--- a/src/Model/TestCaseQuery.php
+++ b/src/Model/TestCaseQuery.php
@@ -391,6 +391,21 @@ class TestCaseQuery implements ModelInterface, ArrayAccess, \JsonSerializable
         return self::$openAPIModelName;
     }
 
+    public const STEPS_TYPE_CLASSIC = 'classic';
+    public const STEPS_TYPE_GHERKIN = 'gherkin';
+
+    /**
+     * Gets allowable values of the enum
+     *
+     * @return string[]
+     */
+    public function getStepsTypeAllowableValues()
+    {
+        return [
+            self::STEPS_TYPE_CLASSIC,
+            self::STEPS_TYPE_GHERKIN,
+        ];
+    }
 
     /**
      * Associative array for storing property values
@@ -467,6 +482,15 @@ class TestCaseQuery implements ModelInterface, ArrayAccess, \JsonSerializable
         if ($this->container['testCaseId'] === null) {
             $invalidProperties[] = "'testCaseId' can't be null";
         }
+        $allowedValues = $this->getStepsTypeAllowableValues();
+        if (!is_null($this->container['stepsType']) && !in_array($this->container['stepsType'], $allowedValues, true)) {
+            $invalidProperties[] = sprintf(
+                "invalid value '%s' for 'stepsType', must be one of '%s'",
+                $this->container['stepsType'],
+                implode("', '", $allowedValues)
+            );
+        }
+
         return $invalidProperties;
     }
 
@@ -1058,6 +1082,16 @@ class TestCaseQuery implements ModelInterface, ArrayAccess, \JsonSerializable
                 unset($nullablesSetToNull[$index]);
                 $this->setOpenAPINullablesSetToNull($nullablesSetToNull);
             }
+        }
+        $allowedValues = $this->getStepsTypeAllowableValues();
+        if (!is_null($stepsType) && !in_array($stepsType, $allowedValues, true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value '%s' for 'stepsType', must be one of '%s'",
+                    $stepsType,
+                    implode("', '", $allowedValues)
+                )
+            );
         }
         $this->container['stepsType'] = $stepsType;
 

--- a/src/Model/TestCaseUpdate.php
+++ b/src/Model/TestCaseUpdate.php
@@ -72,6 +72,7 @@ class TestCaseUpdate implements ModelInterface, ArrayAccess, \JsonSerializable
         'milestoneId' => 'int',
         'automation' => 'int',
         'status' => 'int',
+        'stepsType' => 'string',
         'attachments' => 'string[]',
         'steps' => '\Qase\APIClientV1\Model\TestStepCreate[]',
         'tags' => 'string[]',
@@ -102,6 +103,7 @@ class TestCaseUpdate implements ModelInterface, ArrayAccess, \JsonSerializable
         'milestoneId' => 'int64',
         'automation' => null,
         'status' => null,
+        'stepsType' => null,
         'attachments' => null,
         'steps' => null,
         'tags' => null,
@@ -130,6 +132,7 @@ class TestCaseUpdate implements ModelInterface, ArrayAccess, \JsonSerializable
         'milestoneId' => false,
         'automation' => false,
         'status' => false,
+        'stepsType' => false,
         'attachments' => false,
         'steps' => false,
         'tags' => false,
@@ -238,6 +241,7 @@ class TestCaseUpdate implements ModelInterface, ArrayAccess, \JsonSerializable
         'milestoneId' => 'milestone_id',
         'automation' => 'automation',
         'status' => 'status',
+        'stepsType' => 'steps_type',
         'attachments' => 'attachments',
         'steps' => 'steps',
         'tags' => 'tags',
@@ -266,6 +270,7 @@ class TestCaseUpdate implements ModelInterface, ArrayAccess, \JsonSerializable
         'milestoneId' => 'setMilestoneId',
         'automation' => 'setAutomation',
         'status' => 'setStatus',
+        'stepsType' => 'setStepsType',
         'attachments' => 'setAttachments',
         'steps' => 'setSteps',
         'tags' => 'setTags',
@@ -294,6 +299,7 @@ class TestCaseUpdate implements ModelInterface, ArrayAccess, \JsonSerializable
         'milestoneId' => 'getMilestoneId',
         'automation' => 'getAutomation',
         'status' => 'getStatus',
+        'stepsType' => 'getStepsType',
         'attachments' => 'getAttachments',
         'steps' => 'getSteps',
         'tags' => 'getTags',
@@ -343,6 +349,21 @@ class TestCaseUpdate implements ModelInterface, ArrayAccess, \JsonSerializable
         return self::$openAPIModelName;
     }
 
+    public const STEPS_TYPE_CLASSIC = 'classic';
+    public const STEPS_TYPE_GHERKIN = 'gherkin';
+
+    /**
+     * Gets allowable values of the enum
+     *
+     * @return string[]
+     */
+    public function getStepsTypeAllowableValues()
+    {
+        return [
+            self::STEPS_TYPE_CLASSIC,
+            self::STEPS_TYPE_GHERKIN,
+        ];
+    }
 
     /**
      * Associative array for storing property values
@@ -373,6 +394,7 @@ class TestCaseUpdate implements ModelInterface, ArrayAccess, \JsonSerializable
         $this->setIfExists('milestoneId', $data ?? [], null);
         $this->setIfExists('automation', $data ?? [], null);
         $this->setIfExists('status', $data ?? [], null);
+        $this->setIfExists('stepsType', $data ?? [], 'classic');
         $this->setIfExists('attachments', $data ?? [], null);
         $this->setIfExists('steps', $data ?? [], null);
         $this->setIfExists('tags', $data ?? [], null);
@@ -410,6 +432,15 @@ class TestCaseUpdate implements ModelInterface, ArrayAccess, \JsonSerializable
 
         if (!is_null($this->container['title']) && (mb_strlen($this->container['title']) > 255)) {
             $invalidProperties[] = "invalid value for 'title', the character length must be smaller than or equal to 255.";
+        }
+
+        $allowedValues = $this->getStepsTypeAllowableValues();
+        if (!is_null($this->container['stepsType']) && !in_array($this->container['stepsType'], $allowedValues, true)) {
+            $invalidProperties[] = sprintf(
+                "invalid value '%s' for 'stepsType', must be one of '%s'",
+                $this->container['stepsType'],
+                implode("', '", $allowedValues)
+            );
         }
 
         return $invalidProperties;
@@ -805,6 +836,43 @@ class TestCaseUpdate implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable status cannot be null');
         }
         $this->container['status'] = $status;
+
+        return $this;
+    }
+
+    /**
+     * Gets stepsType
+     *
+     * @return string|null
+     */
+    public function getStepsType()
+    {
+        return $this->container['stepsType'];
+    }
+
+    /**
+     * Sets stepsType
+     *
+     * @param string|null $stepsType Determines the format of the steps field. When \"classic\", steps use the standard action/expected_result/data format. When \"gherkin\", steps use the {value: \"Given...\\nWhen...\\nThen...\"} format.
+     *
+     * @return self
+     */
+    public function setStepsType($stepsType)
+    {
+        if (is_null($stepsType)) {
+            throw new \InvalidArgumentException('non-nullable stepsType cannot be null');
+        }
+        $allowedValues = $this->getStepsTypeAllowableValues();
+        if (!in_array($stepsType, $allowedValues, true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value '%s' for 'stepsType', must be one of '%s'",
+                    $stepsType,
+                    implode("', '", $allowedValues)
+                )
+            );
+        }
+        $this->container['stepsType'] = $stepsType;
 
         return $this;
     }

--- a/src/Model/TestCasebulkCasesInner.php
+++ b/src/Model/TestCasebulkCasesInner.php
@@ -72,6 +72,7 @@ class TestCasebulkCasesInner implements ModelInterface, ArrayAccess, \JsonSerial
         'milestoneId' => 'int',
         'automation' => 'int',
         'status' => 'int',
+        'stepsType' => 'string',
         'attachments' => 'string[]',
         'steps' => '\Qase\APIClientV1\Model\TestStepCreate[]',
         'tags' => 'string[]',
@@ -105,6 +106,7 @@ class TestCasebulkCasesInner implements ModelInterface, ArrayAccess, \JsonSerial
         'milestoneId' => 'int64',
         'automation' => null,
         'status' => null,
+        'stepsType' => null,
         'attachments' => null,
         'steps' => null,
         'tags' => null,
@@ -136,6 +138,7 @@ class TestCasebulkCasesInner implements ModelInterface, ArrayAccess, \JsonSerial
         'milestoneId' => false,
         'automation' => false,
         'status' => false,
+        'stepsType' => false,
         'attachments' => false,
         'steps' => false,
         'tags' => false,
@@ -247,6 +250,7 @@ class TestCasebulkCasesInner implements ModelInterface, ArrayAccess, \JsonSerial
         'milestoneId' => 'milestone_id',
         'automation' => 'automation',
         'status' => 'status',
+        'stepsType' => 'steps_type',
         'attachments' => 'attachments',
         'steps' => 'steps',
         'tags' => 'tags',
@@ -278,6 +282,7 @@ class TestCasebulkCasesInner implements ModelInterface, ArrayAccess, \JsonSerial
         'milestoneId' => 'setMilestoneId',
         'automation' => 'setAutomation',
         'status' => 'setStatus',
+        'stepsType' => 'setStepsType',
         'attachments' => 'setAttachments',
         'steps' => 'setSteps',
         'tags' => 'setTags',
@@ -309,6 +314,7 @@ class TestCasebulkCasesInner implements ModelInterface, ArrayAccess, \JsonSerial
         'milestoneId' => 'getMilestoneId',
         'automation' => 'getAutomation',
         'status' => 'getStatus',
+        'stepsType' => 'getStepsType',
         'attachments' => 'getAttachments',
         'steps' => 'getSteps',
         'tags' => 'getTags',
@@ -361,6 +367,21 @@ class TestCasebulkCasesInner implements ModelInterface, ArrayAccess, \JsonSerial
         return self::$openAPIModelName;
     }
 
+    public const STEPS_TYPE_CLASSIC = 'classic';
+    public const STEPS_TYPE_GHERKIN = 'gherkin';
+
+    /**
+     * Gets allowable values of the enum
+     *
+     * @return string[]
+     */
+    public function getStepsTypeAllowableValues()
+    {
+        return [
+            self::STEPS_TYPE_CLASSIC,
+            self::STEPS_TYPE_GHERKIN,
+        ];
+    }
 
     /**
      * Associative array for storing property values
@@ -391,6 +412,7 @@ class TestCasebulkCasesInner implements ModelInterface, ArrayAccess, \JsonSerial
         $this->setIfExists('milestoneId', $data ?? [], null);
         $this->setIfExists('automation', $data ?? [], null);
         $this->setIfExists('status', $data ?? [], null);
+        $this->setIfExists('stepsType', $data ?? [], 'classic');
         $this->setIfExists('attachments', $data ?? [], null);
         $this->setIfExists('steps', $data ?? [], null);
         $this->setIfExists('tags', $data ?? [], null);
@@ -434,6 +456,15 @@ class TestCasebulkCasesInner implements ModelInterface, ArrayAccess, \JsonSerial
         }
         if ((mb_strlen($this->container['title']) > 255)) {
             $invalidProperties[] = "invalid value for 'title', the character length must be smaller than or equal to 255.";
+        }
+
+        $allowedValues = $this->getStepsTypeAllowableValues();
+        if (!is_null($this->container['stepsType']) && !in_array($this->container['stepsType'], $allowedValues, true)) {
+            $invalidProperties[] = sprintf(
+                "invalid value '%s' for 'stepsType', must be one of '%s'",
+                $this->container['stepsType'],
+                implode("', '", $allowedValues)
+            );
         }
 
         return $invalidProperties;
@@ -829,6 +860,43 @@ class TestCasebulkCasesInner implements ModelInterface, ArrayAccess, \JsonSerial
             throw new \InvalidArgumentException('non-nullable status cannot be null');
         }
         $this->container['status'] = $status;
+
+        return $this;
+    }
+
+    /**
+     * Gets stepsType
+     *
+     * @return string|null
+     */
+    public function getStepsType()
+    {
+        return $this->container['stepsType'];
+    }
+
+    /**
+     * Sets stepsType
+     *
+     * @param string|null $stepsType Determines the format of the steps field. When \"classic\", steps use the standard action/expected_result/data format. When \"gherkin\", steps use the {value: \"Given...\\nWhen...\\nThen...\"} format.
+     *
+     * @return self
+     */
+    public function setStepsType($stepsType)
+    {
+        if (is_null($stepsType)) {
+            throw new \InvalidArgumentException('non-nullable stepsType cannot be null');
+        }
+        $allowedValues = $this->getStepsTypeAllowableValues();
+        if (!in_array($stepsType, $allowedValues, true)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value '%s' for 'stepsType', must be one of '%s'",
+                    $stepsType,
+                    implode("', '", $allowedValues)
+                )
+            );
+        }
+        $this->container['stepsType'] = $stepsType;
 
         return $this;
     }

--- a/src/Model/TestStepCreate.php
+++ b/src/Model/TestStepCreate.php
@@ -61,6 +61,7 @@ class TestStepCreate implements ModelInterface, ArrayAccess, \JsonSerializable
         'action' => 'string',
         'expectedResult' => 'string',
         'data' => 'string',
+        'value' => 'string',
         'position' => 'int',
         'attachments' => 'string[]',
         'steps' => 'object[]'
@@ -77,6 +78,7 @@ class TestStepCreate implements ModelInterface, ArrayAccess, \JsonSerializable
         'action' => null,
         'expectedResult' => null,
         'data' => null,
+        'value' => null,
         'position' => null,
         'attachments' => null,
         'steps' => null
@@ -91,6 +93,7 @@ class TestStepCreate implements ModelInterface, ArrayAccess, \JsonSerializable
         'action' => false,
         'expectedResult' => false,
         'data' => false,
+        'value' => false,
         'position' => false,
         'attachments' => false,
         'steps' => false
@@ -185,6 +188,7 @@ class TestStepCreate implements ModelInterface, ArrayAccess, \JsonSerializable
         'action' => 'action',
         'expectedResult' => 'expected_result',
         'data' => 'data',
+        'value' => 'value',
         'position' => 'position',
         'attachments' => 'attachments',
         'steps' => 'steps'
@@ -199,6 +203,7 @@ class TestStepCreate implements ModelInterface, ArrayAccess, \JsonSerializable
         'action' => 'setAction',
         'expectedResult' => 'setExpectedResult',
         'data' => 'setData',
+        'value' => 'setValue',
         'position' => 'setPosition',
         'attachments' => 'setAttachments',
         'steps' => 'setSteps'
@@ -213,6 +218,7 @@ class TestStepCreate implements ModelInterface, ArrayAccess, \JsonSerializable
         'action' => 'getAction',
         'expectedResult' => 'getExpectedResult',
         'data' => 'getData',
+        'value' => 'getValue',
         'position' => 'getPosition',
         'attachments' => 'getAttachments',
         'steps' => 'getSteps'
@@ -278,6 +284,7 @@ class TestStepCreate implements ModelInterface, ArrayAccess, \JsonSerializable
         $this->setIfExists('action', $data ?? [], null);
         $this->setIfExists('expectedResult', $data ?? [], null);
         $this->setIfExists('data', $data ?? [], null);
+        $this->setIfExists('value', $data ?? [], null);
         $this->setIfExists('position', $data ?? [], null);
         $this->setIfExists('attachments', $data ?? [], null);
         $this->setIfExists('steps', $data ?? [], null);
@@ -338,7 +345,7 @@ class TestStepCreate implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets action
      *
-     * @param string|null $action action
+     * @param string|null $action Step action text. Used for classic steps. For gherkin steps, use the \"value\" property instead.
      *
      * @return self
      */
@@ -402,6 +409,33 @@ class TestStepCreate implements ModelInterface, ArrayAccess, \JsonSerializable
             throw new \InvalidArgumentException('non-nullable data cannot be null');
         }
         $this->container['data'] = $data;
+
+        return $this;
+    }
+
+    /**
+     * Gets value
+     *
+     * @return string|null
+     */
+    public function getValue()
+    {
+        return $this->container['value'];
+    }
+
+    /**
+     * Sets value
+     *
+     * @param string|null $value Gherkin scenario text. Used when steps_type is \"gherkin\". Example: \"Given a user exists\\nWhen they log in\\nThen they see the dashboard\"
+     *
+     * @return self
+     */
+    public function setValue($value)
+    {
+        if (is_null($value)) {
+            throw new \InvalidArgumentException('non-nullable value cannot be null');
+        }
+        $this->container['value'] = $value;
 
         return $this;
     }


### PR DESCRIPTION
- Updated version in composer.json to 1.1.9.
- Modified composer.lock content-hash.
- Added stepsType property to multiple models, allowing for 'classic' and 'gherkin' formats for steps.
- Enhanced documentation for TestCase, TestCaseCreate, TestCaseUpdate, and related models to include stepsType details.