### PR TITLE
Fix User-Agent header to follow qase-api-client convention

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
       "Tests\\": "test/"
     }
   },
-  "version": "1.1.9",
+  "version": "1.1.10",
   "scripts": {
     "test": "phpunit"
   },

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -97,11 +97,11 @@ class Configuration
     protected $host = 'https://api.qase.io/v1';
 
     /**
-     * User agent of the HTTP request, set to "OpenAPI-Generator/{version}/PHP" by default
+     * User agent of the HTTP request
      *
      * @var string
      */
-    protected $userAgent = 'OpenAPI-Generator/1.0.0/PHP';
+    protected $userAgent = '';
 
     /**
      * Debug switch (default set to false)
@@ -144,6 +144,28 @@ class Configuration
     public function __construct()
     {
         $this->tempFolderPath = sys_get_temp_dir();
+        $this->userAgent = 'qase-api-client-php/' . self::getPackageVersion();
+    }
+
+    /**
+     * Gets the package version from Composer metadata
+     *
+     * @return string Package version or 'unknown' if not available
+     */
+    public static function getPackageVersion(): string
+    {
+        try {
+            if (class_exists('\Composer\InstalledVersions')) {
+                $version = \Composer\InstalledVersions::getPrettyVersion('qase/qase-api-client');
+                if ($version !== null) {
+                    return $version;
+                }
+            }
+        } catch (\Exception $e) {
+            // Fallback below
+        }
+
+        return 'unknown';
     }
 
     /**

--- a/test/ConfigurationTest.php
+++ b/test/ConfigurationTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Qase\APIClientV1\Test;
+
+use Qase\APIClientV1\Configuration;
+use PHPUnit\Framework\TestCase;
+
+class ConfigurationTest extends TestCase
+{
+    public function setUp(): void
+    {
+        // Reset the default configuration singleton between tests
+        Configuration::setDefaultConfiguration(new Configuration());
+    }
+
+    public function testUserAgentContainsQaseApiClient(): void
+    {
+        $config = new Configuration();
+        $userAgent = $config->getUserAgent();
+
+        $this->assertMatchesRegularExpression(
+            '/qase-api-client[\w-]*/i',
+            $userAgent,
+            'User-Agent must contain "qase-api-client" substring for backend analytics'
+        );
+    }
+
+    public function testUserAgentFollowsConvention(): void
+    {
+        $config = new Configuration();
+        $userAgent = $config->getUserAgent();
+
+        $this->assertMatchesRegularExpression(
+            '/^qase-api-client-php\/.+$/',
+            $userAgent,
+            'User-Agent must follow the format: qase-api-client-php/<version>'
+        );
+    }
+
+    public function testUserAgentIncludesVersion(): void
+    {
+        $config = new Configuration();
+        $userAgent = $config->getUserAgent();
+
+        // Version should be a semver-like string, not "unknown" in a properly installed env
+        $this->assertStringStartsWith('qase-api-client-php/', $userAgent);
+
+        $version = substr($userAgent, strlen('qase-api-client-php/'));
+        $this->assertNotEmpty($version, 'Version part must not be empty');
+    }
+
+    public function testUserAgentCanBeOverridden(): void
+    {
+        $config = new Configuration();
+        $customAgent = 'qase-api-client-php/1.0.0 custom-integration/2.0';
+        $config->setUserAgent($customAgent);
+
+        $this->assertEquals($customAgent, $config->getUserAgent());
+    }
+
+    public function testDefaultConfigurationHasCorrectUserAgent(): void
+    {
+        $config = Configuration::getDefaultConfiguration();
+        $userAgent = $config->getUserAgent();
+
+        $this->assertMatchesRegularExpression(
+            '/qase-api-client[\w-]*/i',
+            $userAgent,
+            'Default configuration User-Agent must contain "qase-api-client"'
+        );
+    }
+
+    public function testGetPackageVersionReturnsString(): void
+    {
+        $version = Configuration::getPackageVersion();
+        $this->assertIsString($version);
+        $this->assertNotEmpty($version);
+    }
+}


### PR DESCRIPTION
## Summary
- Replace default `OpenAPI-Generator/1.0.0/PHP` User-Agent with `qase-api-client-php/<version>` to match the Qase backend analytics convention (`/qase-api-client[\w-]*/i` regex)
- Version is resolved dynamically via `Composer\InstalledVersions::getPrettyVersion()` with a fallback to `'unknown'`
- Add 6 PHPUnit tests validating User-Agent format, substring presence, and override behavior

## Test plan
- [x] All 6 new tests pass (`vendor/bin/phpunit test/ConfigurationTest.php`)
- [x] Verified actual output: `qase-api-client-php/1.1.9`
- [x] Verify backend correctly extracts `qase-api-client-php` as `source_name` in Amplitude