### PR TITLE
chore: update API clients to latest specification

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
       "Tests\\": "test/"
     }
   },
-  "version": "1.1.10",
+  "version": "1.1.11",
   "scripts": {
     "test": "phpunit"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fa07dd5ece0dbf2f76a9df8e2e886119",
+    "content-hash": "6aa31b007394a216a5847afdfa83a53d",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -97,11 +97,11 @@ class Configuration
     protected $host = 'https://api.qase.io/v1';
 
     /**
-     * User agent of the HTTP request
+     * User agent of the HTTP request, set to "OpenAPI-Generator/{version}/PHP" by default
      *
      * @var string
      */
-    protected $userAgent = '';
+    protected $userAgent = 'OpenAPI-Generator/1.0.0/PHP';
 
     /**
      * Debug switch (default set to false)
@@ -144,28 +144,6 @@ class Configuration
     public function __construct()
     {
         $this->tempFolderPath = sys_get_temp_dir();
-        $this->userAgent = 'qase-api-client-php/' . self::getPackageVersion();
-    }
-
-    /**
-     * Gets the package version from Composer metadata
-     *
-     * @return string Package version or 'unknown' if not available
-     */
-    public static function getPackageVersion(): string
-    {
-        try {
-            if (class_exists('\Composer\InstalledVersions')) {
-                $version = \Composer\InstalledVersions::getPrettyVersion('qase/qase-api-client');
-                if ($version !== null) {
-                    return $version;
-                }
-            }
-        } catch (\Exception $e) {
-            // Fallback below
-        }
-
-        return 'unknown';
     }
 
     /**


### PR DESCRIPTION
## Summary

- Updated API clients to the latest OpenAPI specification

### Targets updated:
- v1: 1.1.10 → 1.1.11

### Protected files (skipped):
None

### Warnings:
None